### PR TITLE
fix: disable vercel image optimization to save resources

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
## Summary
- Set `images.unoptimized` to `true` in Next.js config so `next/image` serves original sources instead of Vercel Image Optimization to save resources.